### PR TITLE
Create empty vault before depositing wrapped tokens

### DIFF
--- a/transactions/wrap_fiatToken.cdc
+++ b/transactions/wrap_fiatToken.cdc
@@ -23,7 +23,7 @@ transaction(amount: UFix64) {
             // The signer has not set up a USDCFlow Vault yet
             // so store it in their storage
             signer.save(
-                <-wrappedTokens,
+                <-USDCFlow.createEmptyVault(),
                 to: USDCFlow.VaultStoragePath
             )
 
@@ -36,6 +36,11 @@ transaction(amount: UFix64) {
                 USDCFlow.VaultPublicPath,
                 target: USDCFlow.VaultStoragePath
             )
+
+            let wrappedVaultRef = signer.borrow<&{FungibleToken.Receiver}>(from: USDCFlow.VaultStoragePath)
+                ?? panic("Could not borrow a receiver reference to the USDCFlow.Vault!")
+
+            wrappedVaultRef.deposit(from: <-wrappedTokens)
         }
     }
 }


### PR DESCRIPTION
## Description

Store an empty vault in storage before depositing the wrapped tokens so that the correct deposit event gets emmitted